### PR TITLE
Update uglifycss-lib.js

### DIFF
--- a/uglifycss-lib.js
+++ b/uglifycss-lib.js
@@ -506,7 +506,7 @@ function processString(content, options) {
     content = content.replace(/;+\}/g, "}");
 
     // replace 0(px,em,%) with 0.
-    content = content.replace(/(^|[^.0-9])(?:0?\.)?0(?:ex|ch|r?em|vw|vh|vmin|vmax|cm|mm|in|pt|pc|px|deg|g?rad|turn|m?s|k?Hz|dpi|dpcm|dppx|%)/gi, "$10");
+    content = content.replace(/(^|[^.0-9])(?:0?\.)?0(?:ex|ch|r?em|vw|vh|vmin|vmax|cm|mm|in|pt|pc|px|deg|g?rad|turn|k?Hz|dpi|dpcm|dppx|%)/gi, "$10");
 
     // Replace x.0(px,em,%) with x(px,em,%).
     content = content.replace(/([0-9])\.0(ex|ch|r?em|vw|vh|vmin|vmax|cm|mm|in|pt|pc|px|deg|g?rad|turn|m?s|k?Hz|dpi|dpcm|dppx|%| |;)/gi, "$1$2");


### PR DESCRIPTION
Script incorrectly changed zero durations to zeroes, e.g. 0s -> 0. It does work in some browsers, but is incompatible with the CSS standard (as per http://stackoverflow.com/a/13145406), and does not work in Firefox, therefore breaking some stylesheets.

Real-life example of code broken after minification:

Before:

transition: border-color .15s ease-in-out 0s, box-shadow .15s ease-in-out 0s;

After:

transition:border-color .15s ease-in-out 0,box-shadow .15s ease-in-out 0;

Therefore added a really slight modification of one line.

It will not incorrectly compress zero durations anymore. Loss in compression should be negligible.

Didn't test other non-length units, but other slight changes might be needed.