### PR TITLE
Replacing util.print since its deprecated.

### DIFF
--- a/test.js
+++ b/test.js
@@ -41,5 +41,5 @@ var content =
     "   z-index : 100000;\n" +
     "}\n";
 
-util.print(uglifycss.processString(content, options) + "\n");
+console.log(uglifycss.processString(content, options) + "\n");
 //uglifycss.processFiles(filenames, options) + "\n");

--- a/uglifycss
+++ b/uglifycss
@@ -96,7 +96,7 @@ function parseArguments(argv) {
 
     // . files
     if (nFiles) {
-        util.print(uglifycss.processFiles(params.files, params.options));
+        console.log(uglifycss.processFiles(params.files, params.options));
 
     // . usage
     } else if (stdin.isTTY) {
@@ -110,7 +110,7 @@ function parseArguments(argv) {
         });
 
         stdin.on("end", function () {
-            util.print(uglifycss.processString(content, params.options));
+            console.log(uglifycss.processString(content, params.options));
         });
     }
 


### PR DESCRIPTION
Replaced util.print calls with console.log, since util.print is deprecated (see https://iojs.org/api/util.html#util_util_print)

Keep the great work.